### PR TITLE
Create runwebserver.sh

### DIFF
--- a/runwebserver.sh
+++ b/runwebserver.sh
@@ -1,0 +1,8 @@
+ipAddress=$(hostname -I | cut -d ' ' -f1 | sed -e 's/ //')
+cd web
+source .venv/bin/activate
+sudo screen -S ReconftwWebserver -X kill
+sudo screen -dmS ReconftwWebserver python3 manage.py runserver $ipAddress:8001
+sudo service redis-server start
+sudo screen -S ReconftwCelery -X kill
+sudo screen -dmS ReconftwCelery python3 -m celery -A web worker -l info -P prefork -Q run_scans,default


### PR DESCRIPTION
Alternative to ./reconftw.sh --web-server start.
Adding bash script to runwebserver incase --web-server start does not work based on instruction of @six2dez on how to alternatively start. Run this after installing reconftw + webserver (option2).